### PR TITLE
fix: ISSUE-63 handle iss_sub subject according to RFC 9493 §3.2.3

### DIFF
--- a/secevent/pkg/subject/simple.go
+++ b/secevent/pkg/subject/simple.go
@@ -150,8 +150,8 @@ func (ps *PhoneSubject) Payload() (map[string]interface{}, error) {
 // IssuerSubSubject represents a subject identified by an issuer and subject pair
 type IssuerSubSubject struct {
 	baseSimpleSubject
-	issuer string
-	sub    string
+	iss string
+	sub string
 }
 
 func NewIssuerSubSubject(issuer, sub string) (*IssuerSubSubject, error) {
@@ -170,13 +170,13 @@ func NewIssuerSubSubject(issuer, sub string) (*IssuerSubSubject, error) {
 		baseSimpleSubject: baseSimpleSubject{
 			format: FormatIssuerSub,
 		},
-		issuer: issuer,
-		sub:    sub,
+		iss: issuer,
+		sub: sub,
 	}, nil
 }
 
 func (iss *IssuerSubSubject) Issuer() string {
-	return iss.issuer
+	return iss.iss
 }
 
 func (iss *IssuerSubSubject) Sub() string {
@@ -186,7 +186,7 @@ func (iss *IssuerSubSubject) Sub() string {
 func (iss *IssuerSubSubject) MarshalJSON() ([]byte, error) {
 	m := map[string]string{
 		"format": string(iss.format),
-		"iss":    iss.issuer,
+		"iss":    iss.iss,
 		"sub":    iss.sub,
 	}
 
@@ -208,9 +208,9 @@ func (iss *IssuerSubSubject) UnmarshalJSON(data []byte) error {
 	// Parser expects issuer while transmitter sends iss for ISS Sub subject type
 	// RFC 9493 uses "iss"; accept "issuer" for backward compatibility.
 	if v := strings.TrimSpace(raw["iss"]); v != "" {
-		iss.issuer = v
+		iss.iss = v
 	} else {
-		iss.issuer = strings.TrimSpace(raw["issuer"])
+		iss.iss = strings.TrimSpace(raw["issuer"])
 	}
 	iss.sub = strings.TrimSpace(raw["sub"])
 
@@ -218,7 +218,7 @@ func (iss *IssuerSubSubject) UnmarshalJSON(data []byte) error {
 }
 
 func (iss *IssuerSubSubject) Validate() error {
-	if strings.TrimSpace(iss.issuer) == "" {
+	if strings.TrimSpace(iss.iss) == "" {
 		return NewError(ErrCodeMissingValue, "issuer is required", "iss")
 	}
 
@@ -232,7 +232,7 @@ func (iss *IssuerSubSubject) Validate() error {
 func (iss *IssuerSubSubject) Payload() (map[string]interface{}, error) {
     return map[string]interface{}{
         "format": string(iss.format),
-        "iss":    iss.issuer,
+        "iss":    iss.iss,
         "sub":    iss.sub,
     }, nil
 }

--- a/secevent/pkg/subject/simple.go
+++ b/secevent/pkg/subject/simple.go
@@ -159,7 +159,7 @@ func NewIssuerSubSubject(issuer, sub string) (*IssuerSubSubject, error) {
 	sub = strings.TrimSpace(sub)
 
 	if issuer == "" {
-		return nil, NewError(ErrCodeMissingValue, "issuer is required", "issuer")
+		return nil, NewError(ErrCodeMissingValue, "issuer is required", "iss")
 	}
 
 	if sub == "" {
@@ -186,7 +186,7 @@ func (iss *IssuerSubSubject) Sub() string {
 func (iss *IssuerSubSubject) MarshalJSON() ([]byte, error) {
 	m := map[string]string{
 		"format": string(iss.format),
-		"issuer": iss.issuer,
+		"iss":    iss.issuer,
 		"sub":    iss.sub,
 	}
 
@@ -204,7 +204,14 @@ func (iss *IssuerSubSubject) UnmarshalJSON(data []byte) error {
 	}
 
 	iss.format = FormatIssuerSub
-	iss.issuer = strings.TrimSpace(raw["issuer"])
+	// ISSUE-63: https://github.com/SGNL-ai/caep.dev/issues/63
+	// Parser expects issuer while transmitter sends iss for ISS Sub subject type
+	// RFC 9493 uses "iss"; accept "issuer" for backward compatibility.
+	if v := strings.TrimSpace(raw["iss"]); v != "" {
+		iss.issuer = v
+	} else {
+		iss.issuer = strings.TrimSpace(raw["issuer"])
+	}
 	iss.sub = strings.TrimSpace(raw["sub"])
 
 	return nil
@@ -212,7 +219,7 @@ func (iss *IssuerSubSubject) UnmarshalJSON(data []byte) error {
 
 func (iss *IssuerSubSubject) Validate() error {
 	if strings.TrimSpace(iss.issuer) == "" {
-		return NewError(ErrCodeMissingValue, "issuer is required", "issuer")
+		return NewError(ErrCodeMissingValue, "issuer is required", "iss")
 	}
 
 	if strings.TrimSpace(iss.sub) == "" {
@@ -225,7 +232,7 @@ func (iss *IssuerSubSubject) Validate() error {
 func (iss *IssuerSubSubject) Payload() (map[string]interface{}, error) {
     return map[string]interface{}{
         "format": string(iss.format),
-        "issuer": iss.issuer,
+        "iss":    iss.issuer,
         "sub":    iss.sub,
     }, nil
 }


### PR DESCRIPTION
Description:
- Fixes: [Issue-63](https://github.com/SGNL-ai/caep.dev/issues/63)
- OpenID RFC: [RFC 9493 §3.2.3 (Issuer and Subject Identifier Format)](https://www.rfc-editor.org/rfc/rfc9493.html#name-issuer-and-subject-identifi) requires the `iss_sub` subject to use the members `iss` and `sub`. The parser previously only read `issuer`, which caused SET parsing to fail for RFC-compliant tokens that use `iss`.

Changes:
- UnmarshalJSON: Accept `iss` as the issuer member; fall back to `issuer` for backward compatibility.
- MarshalJSON / Payload: Emit `iss` instead of `issuer` so serialized output is RFC 9493 compliant.
- Errors: Use the field name `iss` in subject validation errors for the issuer, consistent with the spec.
- Internal struct field remains `issuer`; only the JSON key is `iss`, matching the existing pattern used in same package.