### PR TITLE
[CONTID-11148] Remove dependabot github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,14 +35,3 @@ updates:
       - "go"
 
   # GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    cooldown:
-      default-days: 7
-    labels:
-      - "dependencies"
-      - "github-actions"


### PR DESCRIPTION
Remove github-actions package ecosystem from Dependabot configuration.

GHA versions are explicitly allowlisted and AppSec will reach out when specific vulnerabilities need updates.

Jira: https://jira.cs.sys/browse/CONTID-11148

LLM Agent(s) contributed to this PR.